### PR TITLE
[FEATURE] Add extra_hosts to phpfpm container

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,6 +42,8 @@ docker_images:
   'elasticsearch': 'sinso/elasticsearch-neos'
 #  redis:
 
+extra_hosts: {}
+
 source_ref_stripped: "{{ source_ref | replace('/', '-') }}"
 
 new_instance_vars_hash: "{{ lookup('md5hash', 'instance_vars/' + instance + '.yml') }}"

--- a/tasks/docker_containers/phpfpm.yml
+++ b/tasks/docker_containers/phpfpm.yml
@@ -53,4 +53,5 @@
       PIWIK_TOKEN: "{{ piwik_token }}"
     links: "{{ links }}"
     volumes: "{{ volumes }}"
+    extra_hosts; "{{ extra_hosts }}"
   when: docker_containers.phpfpm is defined


### PR DESCRIPTION
Use docker's `--add-hosts` feature to add hosts-to-IP mappings to `/etc/hosts`.